### PR TITLE
Fix review rating field in API

### DIFF
--- a/src/app/api/write-review/[bookId]/route.js
+++ b/src/app/api/write-review/[bookId]/route.js
@@ -22,7 +22,7 @@ export async function POST(req, { params }) {
     reviewer,
     review_text: text,
     review_date: new Date().toISOString().split('T')[0],
-    rating: parseInt(rating)
+    review_rating: parseInt(rating)
   };
 
   if (!Array.isArray(book.reviews)) {
@@ -31,7 +31,7 @@ export async function POST(req, { params }) {
 
   book.reviews.push(newReview);
 
-  const total = book.reviews.reduce((sum, r) => sum + (r.rating || 0), 0);
+  const total = book.reviews.reduce((sum, r) => sum + (r.review_rating || 0), 0);
   book.rating = total / book.reviews.length;
 
   await book.save();


### PR DESCRIPTION
## Summary
- correct `newReview` rating property name in write-review API
- fix rating calculation to use `review_rating`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a936df7a88325967d3322c40c6d9b