### PR TITLE
Fix redirect url in save-review route

### DIFF
--- a/src/app/api/save-review/route.js
+++ b/src/app/api/save-review/route.js
@@ -40,7 +40,7 @@ export async function POST(req) {
   return new Response(null, {
     status: 303,
     headers: {
-      Location: "/thanks?" + new URLSearchParams({ name, rating, review, bookId }),
+      Location: `/thanks?${params}`,
     },
-  });  
+  });
 }


### PR DESCRIPTION
## Summary
- reuse URLSearchParams instance when redirecting after saving a book review

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686a94a069a48325b444c49b1af30ac5